### PR TITLE
Only turn on tokio features that are used by this crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "1.5.0", features = ["full"] }
+tokio = { version = "1.5.0", features = ["macros", "rt-multi-thread", "sync", "time"] }
 futures = "0.3.14"
 thiserror = "1.0"
 


### PR DESCRIPTION
Hi! It looks like this crate doesn't actually need all of tokio's features that are turned on by `full`-- I turned them all off and then turned them back on one-by-one until the tests passed. 

This way, crates that depend on this one won't be forced to use `full` by feature unification.

Thanks!