### PR TITLE
upgrade `lru` dependency to `0.7.8`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ futures = "0.3.14"
 thiserror = "1.0"
 
 # Optional feature based dependencies
-lru = { version = "0.6.5", optional = true }
+lru = { version = "0.7.8", optional = true }
 
 [dev-dependencies]
 cache_loader_async_macros = { path = "./cache-loader-async-macros" }


### PR DESCRIPTION
This fixes this vulnerability https://github.com/advisories/GHSA-v362-2895-h9r2